### PR TITLE
build_atom and hedge import fix

### DIFF
--- a/graphbrain/cognition/agents/corefs_names.py
+++ b/graphbrain/cognition/agents/corefs_names.py
@@ -5,7 +5,7 @@ import progressbar
 from igraph import Graph
 from unidecode import unidecode
 
-from graphbrain import hedge, build_atom
+from graphbrain.hyperedge import hedge, build_atom
 from graphbrain.cognition.agent import Agent
 from graphbrain.meaning.concepts import has_proper_concept
 from graphbrain.meaning.corefs import make_corefs_ops

--- a/graphbrain/cognition/agents/corefs_unidecode.py
+++ b/graphbrain/cognition/agents/corefs_unidecode.py
@@ -2,7 +2,7 @@ import logging
 
 from unidecode import unidecode
 
-from graphbrain import hedge
+from graphbrain.hyperedge import hedge
 from graphbrain.cognition.agent import Agent
 from graphbrain.meaning.corefs import make_corefs_ops
 


### PR DESCRIPTION
Updating the import of build_atom and hedge (from graphbrain to graphbrain.hyperedge) in corefs_unidecoe et corefs_names agent.